### PR TITLE
Update order of middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ import logger from 'redux-logger'; // Add-on you might want
 import rootReducer from '../reducers/index';
 
 const configureStore = (preloadedState: any) =>
-  createStore(rootReducer, preloadedState, applyMiddleware(logger, thunk));
+  createStore(rootReducer, preloadedState, applyMiddleware(thunk, logger));
 
 export { configureStore };
 ```


### PR DESCRIPTION
Changing the order fixes an “undefined action” that get’s logged - see
this issue
https://github.com/reduxjs/redux-thunk/issues/91