### PR TITLE
Add unsubscribe callback as return type of mapStateToProps

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,11 @@ export class MyComponent {
   @State() name: string;
  
   changeName: Action;
-  
+
+  private unsubscribe: () => void;
+   
   componentWillLoad() {
-    this.store.mapStateToProps(this, (state) => {
+    this.unsubscribe = this.store.mapStateToProps(this, (state) => {
       const {
         myReducer: { name }
       } = state;
@@ -87,6 +89,10 @@ export class MyComponent {
  
   doNameChange(newName: string) {
     this.changeName(newName);
+  }
+
+  componentDidUnload() {
+    this.unsubscribe();
   }
 }
 ```

--- a/src/global/interfaces.ts
+++ b/src/global/interfaces.ts
@@ -4,7 +4,7 @@ export interface Store {
   getState: () => any;
   getStore: () => any;
   setStore: (any: any) => void;
-  mapStateToProps: (component: any, props: any) => void;
+  mapStateToProps: (component: any, props: any) => () => void;
   mapDispatchToProps: (component: any, props: any) => void;
 };
 

--- a/src/global/store.ts
+++ b/src/global/store.ts
@@ -39,9 +39,11 @@ Context.store = (function() {
       });
     };
 
-    _store.subscribe(() => _mapStateToProps(component, mapState));
+    const unsubscribe = _store.subscribe(() => _mapStateToProps(component, mapState));
 
     _mapStateToProps(component, mapState);
+
+    return unsubscribe;
   }
 
   return {


### PR DESCRIPTION
Useful when used with router. Subscriptions have to be unsubscribed to prevent memory leaks.