### PR TITLE
Fix deprecated componentDidUnload

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ export class MyComponent {
     store.mapDispatchToProps(this, { changeName });
   }
 
-  componentDidUnload() {
+  disconnectedCallback() {
     this.unsubscribe();
   }
 


### PR DESCRIPTION
Since Stencil@2.0 componentDidUnload is deprecated:

- componentDidUnload: use disconnectedCallback instead of componentDidUnload (https://github.com/ionic-team/stencil/commit/4e45862f73609599a7195fcf5c93d9fb39492154)